### PR TITLE
Added simple event handling

### DIFF
--- a/fdf/fdf_globals.py
+++ b/fdf/fdf_globals.py
@@ -17,6 +17,11 @@ FDF_DIR = os.path.dirname(os.path.abspath(__file__))
 MDS_SERVERS = {
     'nstx': 'skylark.pppl.gov:8501'
 }
+
+EVENT_SERVERS = {
+    'nstx': 'skylark.pppl.gov:8501',
+    'ltx': 'lithos.pppl.gov:8000'
+}
 """Dictionary: machine-name key paired to MDS server"""
 
 LOGBOOK_CREDENTIALS = {


### PR DESCRIPTION
you can use nstx.setevent(event, shotnumber=None, data=None) to send
events, and nstx.wfevent(event, timeout=0) to wait for events with a
timeout if supplied. Note, the wfevent is blocking.
